### PR TITLE
fixed Lodestone Bug with ImpactFrames

### DIFF
--- a/src/main/java/com/finderfeed/fdlib/commands/FDCommandsRegistry.java
+++ b/src/main/java/com/finderfeed/fdlib/commands/FDCommandsRegistry.java
@@ -13,6 +13,7 @@ import com.finderfeed.fdlib.systems.bedrock.animations.animation_system.Animatio
 import com.finderfeed.fdlib.systems.config.JsonConfig;
 import com.finderfeed.fdlib.systems.config.packets.JsonConfigSyncPacket;
 import com.finderfeed.fdlib.systems.config.packets.TriggerClientsideConfigReloadPacket;
+import com.finderfeed.fdlib.systems.impact_frames.ImpactFrame;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
@@ -109,6 +110,25 @@ public class FDCommandsRegistry {
                                                     return 1;
                                                 })
                                         )
+                                ).then(Commands.literal("impact_test")
+                                        .requires(stack -> stack.hasPermission(2))
+                                        .executes(ctx -> {
+                                            ServerPlayer player = ctx.getSource().getPlayerOrException();
+                                            ServerLevel level = player.serverLevel();
+
+                                            FDLibCalls.sendImpactFrames(
+                                                    level,
+                                                    player.position(),
+                                                    60,
+                                                    new ImpactFrame().setDuration(2),
+                                                    new ImpactFrame().setDuration(1).setInverted(true),
+                                                    new ImpactFrame().setDuration(1),
+                                                    new ImpactFrame().setDuration(1).setInverted(true),
+                                                    new ImpactFrame().setDuration(1)
+                                            );
+
+                                            return 1;
+                                        })
                                 )
 
                 )

--- a/src/main/java/com/finderfeed/fdlib/systems/impact_frames/ImpactFramesHandler.java
+++ b/src/main/java/com/finderfeed/fdlib/systems/impact_frames/ImpactFramesHandler.java
@@ -8,12 +8,14 @@ import com.finderfeed.fdlib.systems.post_shaders.FDRenderPostShaderEvent;
 import com.mojang.blaze3d.pipeline.RenderTarget;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.PostChain;
+import net.minecraft.network.chat.Component;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import org.joml.Vector2i;
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL30;
 
 import java.io.IOException;
 import java.util.*;
@@ -45,15 +47,11 @@ public class ImpactFramesHandler {
     }
 
     @SubscribeEvent
-    public static void renderImpactFrameShader(FDRenderPostShaderEvent.Level event){
-
-
-        if (isImpactFrameShaderActive()){
-            beforePostEffect();
+    public static void renderImpactFrameShader(FDRenderPostShaderEvent.Level event) {
+        if (isImpactFrameShaderActive()) {
             event.doDefaultShaderBeforeShaderStuff();
             impactFrameShader.process(event.getPartialTicks());
         }
-
     }
 
     private static void manageImpactFrames(){
@@ -98,49 +96,43 @@ public class ImpactFramesHandler {
         FDClientHelpers.setShaderUniform(impactFrameShader,"invert", frame.isInverted() ? 1 : 0);
     }
 
-    public static void beforePostEffect(){
+    public static void beforePostEffect() {
+        if (!isImpactFrameShaderActive()) return;
 
-        if (isImpactFrameShaderActive()) {
-            RenderTarget main = Minecraft.getInstance().getMainRenderTarget();
-            main.bindRead();
+        RenderTarget main = Minecraft.getInstance().getMainRenderTarget();
+        main.bindRead();
 
+        int width = main.width;
+        int height = main.height;
 
-            int width = GL11.glGetTexLevelParameteri(GL11.GL_TEXTURE_2D, 0, GL11.GL_TEXTURE_WIDTH);
-            int height = GL11.glGetTexLevelParameteri(GL11.GL_TEXTURE_2D, 0, GL11.GL_TEXTURE_HEIGHT);
-
-            float[] pixel = new float[3];
-
-            int hhalfW = width / 4;
-            int hhalfH = height / 4;
-
-            Vector2i[] samplePoints = new Vector2i[]{
-                    //line on bottom
-                    new Vector2i(hhalfW, hhalfH),
-                    new Vector2i(hhalfW * 2, hhalfH),
-                    new Vector2i(hhalfW * 3, hhalfH),
-                    //line on center
-                    new Vector2i(hhalfW, hhalfH * 2),
-                    new Vector2i(hhalfW * 2, hhalfH * 2),
-                    new Vector2i(hhalfW * 3, hhalfH * 2),
-                    //line on top
-                    new Vector2i(hhalfW, hhalfH * 3),
-                    new Vector2i(hhalfW * 2, hhalfH * 3),
-                    new Vector2i(hhalfW * 3, hhalfH * 3),
-            };
-
-            float maxGrayscale = 0.0f;
-
-            for (Vector2i point : samplePoints) {
-
-                GL11.glReadPixels(point.x, point.y, 1, 1, GL11.GL_RGB, GL11.GL_FLOAT, pixel);
-
-                float grayscale = Math.max(pixel[0], Math.max(pixel[1], pixel[2]));
-                maxGrayscale = Math.max(maxGrayscale, grayscale);
-            }
-
-            FDClientHelpers.setShaderUniform(impactFrameShader, "maxEstimatedGrayscale", maxGrayscale);
+        if (width <= 0 || height <= 0) {
+            FDLib.LOGGER.info("invalid size: {}x{}", width, height);
+            return;
         }
 
+        int fbo = org.lwjgl.opengl.GL11.glGetInteger(org.lwjgl.opengl.GL30.GL_READ_FRAMEBUFFER_BINDING);
+        int status = org.lwjgl.opengl.GL30.glCheckFramebufferStatus(org.lwjgl.opengl.GL30.GL_READ_FRAMEBUFFER);
+        int readBuffer = org.lwjgl.opengl.GL11.glGetInteger(org.lwjgl.opengl.GL11.GL_READ_BUFFER);
+
+        FDLib.LOGGER.info("FBO: {} | status: {} | readBuffer: {}", fbo, status, readBuffer);
+
+        float[] pixel = new float[3];
+
+        int x = width / 2;
+        int y = height / 2;
+
+        int errBefore = org.lwjgl.opengl.GL11.glGetError();
+
+        org.lwjgl.opengl.GL11.glReadPixels(x, y, 1, 1, org.lwjgl.opengl.GL11.GL_RGB, org.lwjgl.opengl.GL11.GL_FLOAT, pixel);
+
+        int errAfter = org.lwjgl.opengl.GL11.glGetError();
+
+        FDLib.LOGGER.info("read @ ({}, {}) -> {}, {}, {}", x, y, pixel[0], pixel[1], pixel[2]);
+        FDLib.LOGGER.info("GL error before: {} | after: {}", errBefore, errAfter);
+
+        float grayscale = Math.max(pixel[0], Math.max(pixel[1], pixel[2]));
+
+        FDClientHelpers.setShaderUniform(impactFrameShader, "maxEstimatedGrayscale", grayscale);
     }
 
     public static boolean isImpactFrameShaderActive(){

--- a/src/main/resources/assets/fdlib/shaders/program/impact_frame.fsh
+++ b/src/main/resources/assets/fdlib/shaders/program/impact_frame.fsh
@@ -1,41 +1,66 @@
 #version 150
 
 uniform sampler2D DiffuseSampler;
-uniform vec2 ScreenSize;
+uniform vec2 OutSize;
 uniform float treshhold;
 uniform float treshholdLerp;
 uniform float invert;
-uniform float maxEstimatedGrayscale;
 
 in vec2 texCoord;
 
 out vec4 fragColor;
 
-void main(){
+float maxGray(vec4 c) {
+    return max(max(c.r, c.g), c.b);
+}
 
+float estimateSceneGray() {
+    vec2 s = vec2(OutSize.x, OutSize.y);
+    vec2 p1 = vec2(s.x * 0.25, s.y * 0.25);
+    vec2 p2 = vec2(s.x * 0.50, s.y * 0.25);
+    vec2 p3 = vec2(s.x * 0.75, s.y * 0.25);
+    vec2 p4 = vec2(s.x * 0.25, s.y * 0.50);
+    vec2 p5 = vec2(s.x * 0.50, s.y * 0.50);
+    vec2 p6 = vec2(s.x * 0.75, s.y * 0.50);
+    vec2 p7 = vec2(s.x * 0.25, s.y * 0.75);
+    vec2 p8 = vec2(s.x * 0.50, s.y * 0.75);
+    vec2 p9 = vec2(s.x * 0.75, s.y * 0.75);
 
+    float m = 0.0;
+    m = max(m, maxGray(texture(DiffuseSampler, p1 / s)));
+    m = max(m, maxGray(texture(DiffuseSampler, p2 / s)));
+    m = max(m, maxGray(texture(DiffuseSampler, p3 / s)));
+    m = max(m, maxGray(texture(DiffuseSampler, p4 / s)));
+    m = max(m, maxGray(texture(DiffuseSampler, p5 / s)));
+    m = max(m, maxGray(texture(DiffuseSampler, p6 / s)));
+    m = max(m, maxGray(texture(DiffuseSampler, p7 / s)));
+    m = max(m, maxGray(texture(DiffuseSampler, p8 / s)));
+    m = max(m, maxGray(texture(DiffuseSampler, p9 / s)));
+    return m;
+}
+
+void main() {
     vec4 color = texture(DiffuseSampler, texCoord);
 
-    float gray = max(max(color.x,color.y),color.z);
+    float gray = maxGray(color);
+    float maxEstimatedGrayscale = estimateSceneGray();
 
-    gray /= maxEstimatedGrayscale;
+    gray /= max(maxEstimatedGrayscale, 0.001);
+    gray = clamp(gray, 0.0, 1.0);
 
-    if (gray > treshhold){
-        gray = 1;
-    }else{
-        if (treshholdLerp != 0){
-            float v = treshhold - gray;
-            gray = smoothstep(0,1,1 - min(1,v / treshholdLerp));
-        }else{
-            gray = 0;
-        }
+    float edge;
 
+    if (treshholdLerp != 0) {
+        edge = smoothstep(treshhold - treshholdLerp, treshhold + treshholdLerp, gray);
+    } else {
+        edge = step(treshhold, gray);
     }
 
-    if (invert > 0){
+    gray = edge;
+
+    if (invert > 0) {
         gray = 1 - gray;
     }
 
-    fragColor = vec4(gray,gray,gray,color.a);
-
+    fragColor = vec4(gray, gray, gray, color.a);
 }

--- a/src/main/resources/assets/fdlib/shaders/program/impact_frame.json
+++ b/src/main/resources/assets/fdlib/shaders/program/impact_frame.json
@@ -16,7 +16,6 @@
     { "name": "OutSize", "type": "float",     "count": 2,  "values": [ 1.0, 1.0 ] },
     { "name": "treshhold", "type": "float",     "count": 1,  "values": [ 1.0 ] },
     { "name": "treshholdLerp", "type": "float",     "count": 1,  "values": [ 1.0 ] },
-    { "name": "invert", "type": "float",     "count": 1,  "values": [ 0.0 ] },
-    { "name": "maxEstimatedGrayscale", "type": "float",     "count": 1,  "values": [ 1.0 ] }
+    { "name": "invert", "type": "float",     "count": 1,  "values": [ 0.0 ] }
   ]
 }


### PR DESCRIPTION
issue

adaptive exposure was using glReadPixels to sample the main framebuffer on the cpu. that worked in vanilla-ish rendering, but lodestone changes the render pipeline enough that the readback was happening on the wrong buffer / wrong timing, so the exposure sample was just getting 0.0 or tripping GL_INVALID_OPERATION.

what I changed

removed the broken framebuffer readback path

basically just moved the screen reading code for the adaptive exposure to the GPU, and out of java